### PR TITLE
Add Compound::get_connections()

### DIFF
--- a/GraphViz/include/compound.h
+++ b/GraphViz/include/compound.h
@@ -143,7 +143,7 @@ class Compound {
         void add_connection(NodeId a, NodeId b);
 
         // get all non hierarchical connections
-        vector<pair<NodeId, NodeId> > get_connections();
+        const vector<pair<NodeId, NodeId> >* get_connections();
 
         pair<NodeId, NodeId> get_connection(ConnId id) const;
 

--- a/GraphViz/src/compound.cpp
+++ b/GraphViz/src/compound.cpp
@@ -284,8 +284,8 @@ void Compound::add_connection(NodeId a, NodeId b) {
     get_node(b)->connections.push_back(id);
 }
 
-vector<pair<NodeId, NodeId> > Compound::get_connections() {
-    return connections;
+const vector<pair<NodeId, NodeId> >* Compound::get_connections() {
+    return &connections;
 }
 
 pair<NodeId, NodeId> Compound::get_connection(ConnId id) const {


### PR DESCRIPTION
Fixes #4 
Returning a copy of the vector of connections could be very expensive -> maybe change Return type to const pointer
